### PR TITLE
feat: update VibeOS project description and add source link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# VibeOS internal files
+.vibeos/

--- a/index.html
+++ b/index.html
@@ -69,7 +69,10 @@
                 <h3>VibeOS</h3>
                 <span class="tag">AI Agent OS</span>
               </div>
-              <p>A self-hosted AI task OS where agents plan work, wait for approval, execute in isolated git worktrees, and surface progress through a Kanban-style UI.</p>
+              <p>A self-hosted AI orchestration platform where software agents plan, code, test, and self-review in isolated git worktrees, with human approval gates and a live Kanban UI.</p>
+            </div>
+            <div class="project-card__actions">
+              <a href="https://github.com/idesi/VibeOS" target="_blank" rel="noopener noreferrer">Source</a>
             </div>
           </article>
 


### PR DESCRIPTION
## Summary

**What changed**

Updates the VibeOS project card on Wsekhon.com with a revised description and a new Source link. The old description was replaced with a more accurate summary of what VibeOS does, and a "Source" link pointing to the GitHub repo was added — matching the existing pattern used by the Osm.js and Log Streak cards.

- `index.html` — updated VibeOS card `<p>` description text; added `project-card__actions` block with Source link (`https://github.com/idesi/VibeOS`)
- `.gitignore` — added `.vibeos/` exclusion

**Testing**

*Automated tests* — no test framework present; site is plain static HTML with no build step or JS logic.

*Manual testing*

1. Open `http://localhost:3094` (or `index.html` directly in a browser)
2. Confirm VibeOS card shows: "A self-hosted AI orchestration platform where software agents plan, code, test, and self-review in isolated git worktrees, with human approval gates and a live Kanban UI."
3. Confirm "Source" link appears below the description on the VibeOS card
4. Click "Source" — verify it opens `https://github.com/idesi/VibeOS` in a new tab
5. Confirm Osm.js and Log Streak cards are unchanged

Closes #6

Co-Authored-By: VibeOS <noreply@vibeos.ai>
